### PR TITLE
Fix 'method redefined' warning

### DIFF
--- a/lib/minitest/perf.rb
+++ b/lib/minitest/perf.rb
@@ -11,7 +11,7 @@ module Minitest::Perf
   autoload :Statistics,  'minitest/perf/statistics'
 
   class << self
-    attr_accessor :database_url
+    attr_writer :database_url
     attr_writer :persistence
 
     def database_url


### PR DESCRIPTION
The warning is:

   minitest-perf-0.1.0/lib/minitest/perf.rb:17: warning: method redefined; discarding old database_url
